### PR TITLE
[AMT-029] Some Third Party API Calls

### DIFF
--- a/lib/services/apis.py
+++ b/lib/services/apis.py
@@ -95,7 +95,7 @@ class NCBI:
             "sort": "relevance",
             "api_key": self.api_key,
             "tool": "clinical-search",
-            "email": "your.name@example.com",
+            "email": self.email
         }
         r = requests.get(self.BASE + "esearch.fcgi", params=params, headers=self.HEADERS, timeout=15)
         r.raise_for_status()
@@ -112,7 +112,7 @@ class NCBI:
             "retmode": "json",
             "api_key": self.api_key,
             "tool": "clinical-search",
-            "email": "your.name@example.com",
+            "email": self.email
         }
         r = requests.get(self.BASE + "esummary.fcgi", params=params, headers=self.HEADERS, timeout=15)
         r.raise_for_status()
@@ -129,7 +129,7 @@ class NCBI:
             "retmode": "text",
             "api_key": self.api_key,
             "tool": "clinical-search",
-            "email": "your.name@example.com",
+            "email": self.email
         }
         r = requests.get(self.BASE + "efetch.fcgi", params=params, headers=self.HEADERS, timeout=15)
         r.raise_for_status()

--- a/lib/services/apis.py
+++ b/lib/services/apis.py
@@ -1,0 +1,161 @@
+""""""
+import time
+import requests
+
+icd10_codes = {
+    'asthma': 'J45.40',
+    'diabetes (type 2)': 'E11.9',
+}
+# https://connect.medlineplus.gov/service?knowledgeResponseType=application%2Fjson&mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c={icd10_code}&mainSearchCriteria.v.dn=&informationRecipient.languageCode.c=en
+
+
+class Medline:
+    def __init__(self, logger):
+        self.logger = logger
+
+    def fetch_medline(self, icd10_code: str):
+        """
+        https://connect.medlineplus.gov/service?
+
+        knowledgeResponseType=application%2Fjson
+            &mainSearchCriteria.v.cs=2.16.840.1.113883.6.90
+            &mainSearchCriteria.v.c={icd10_code}
+            &mainSearchCriteria.v.dn=
+            &informationRecipient.languageCode.c=en
+
+        :return:
+        """
+        url = f"https://connect.medlineplus.gov/service?knowledgeResponseType=application%2Fjson&mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c={icd10_code}&mainSearchCriteria.v.dn=&informationRecipient.languageCode.c=en"
+        headers = {
+            "accept": "application/json"
+        }
+        response = requests.get(url, headers=headers)
+        if response.status_code == 200:
+            data = response.json()
+            return data
+        else:
+            self.logger.error(f"Error fetching Medline data: {response.status_code} - {response.text}")
+            return {"error": "Failed to fetch Medline data"}
+
+
+
+class ClinicalTrials:
+    def __init__(self, logger):
+        self.logger = logger
+
+    def fetch_clinical_trials(self, query: str):
+        """
+        curl -X GET "https://clinicaltrials.gov/api/v2/studies" -H "accept: application/json"
+        :return:
+        """
+        import requests
+        url = "https://clinicaltrials.gov/api/v2/studies"
+        headers = {
+            "accept": "application/json"
+        }
+        response = requests.get(url, headers=headers)
+        if response.status_code == 200:
+            data = response.json()
+            return data
+        else:
+            self.logger.error(f"Error fetching clinical trials: {response.status_code} - {response.text}")
+            return {"error": "Failed to fetch clinical trials"}
+
+
+class NCBI:
+    def __init__(self, email: str, logger, api_key: str):
+        self.email = email
+        self.logger = logger
+        self.api_key = api_key
+
+        self.BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
+        self.HEADERS = {
+            # Good etiquette: identify your tool and give a contact e-mail
+            "User-Agent": f"arsmedicatech/0.1 ({self.email})"
+        }
+
+    def fetch_ncbi_studies(self, query: str):
+        hits, total_found = self.search_pubmed(query, max_records=10, with_abstract=True)
+        print(f"{total_found:,} articles in PubMed; showing {len(hits)} results:\n")
+        for i, art in enumerate(hits, 1):
+            print(f"{i}. {art['title']}  ({art['journal']}, {art['pubdate']})")
+            print(f"   PMID: {art['pmid']}")
+            print(f"   Authors: {art['authors']}")
+            if 'abstract' in art:
+                print(f"   Abstract (truncated): {art['abstract'][:300]}...\n")
+        return hits
+
+    def esearch(self, query, retmax=100):
+        """Return up to retmax PubMed IDs (PMIDs) that match the query."""
+        params = {
+            "db": "pubmed",
+            "term": query,
+            "retmode": "json",
+            "retmax": retmax,
+            "sort": "relevance",
+            "api_key": self.api_key,
+            "tool": "clinical-search",
+            "email": "your.name@example.com",
+        }
+        r = requests.get(self.BASE + "esearch.fcgi", params=params, headers=self.HEADERS, timeout=15)
+        r.raise_for_status()
+        data = r.json()["esearchresult"]
+        return data["idlist"], int(data["count"])  # (list of PMIDs, total hits)
+
+    def esummary(self, pmids):
+        """Return a dict keyed by PMID with title, journal, authors, pubdate, etc."""
+        if not pmids:
+            return {}
+        params = {
+            "db": "pubmed",
+            "id": ",".join(pmids),
+            "retmode": "json",
+            "api_key": self.api_key,
+            "tool": "clinical-search",
+            "email": "your.name@example.com",
+        }
+        r = requests.get(self.BASE + "esummary.fcgi", params=params, headers=self.HEADERS, timeout=15)
+        r.raise_for_status()
+        summaries = r.json()["result"]
+        # The JSON has a useless 'uids' list; filter it out
+        return {pmid: summaries[pmid] for pmid in summaries if pmid != "uids"}
+
+    def efetch_abstract(self, pmid):
+        """Return the plain-text abstract for one PMID (or '' if none)."""
+        params = {
+            "db": "pubmed",
+            "id": pmid,
+            "rettype": "abstract",
+            "retmode": "text",
+            "api_key": self.api_key,
+            "tool": "clinical-search",
+            "email": "your.name@example.com",
+        }
+        r = requests.get(self.BASE + "efetch.fcgi", params=params, headers=self.HEADERS, timeout=15)
+        r.raise_for_status()
+        return r.text.strip()
+
+    def search_pubmed(self, query, max_records=20, with_abstract=False, delay=0.35):
+        """
+        High-level helper.
+        Returns a list of dicts: [{pmid, title, journal, authors, pubdate, abstract?}, ...]
+        """
+        ids, total = self.esearch(query, retmax=max_records)
+        summaries = self.esummary(ids)
+
+        results = []
+        for pmid in ids:
+            doc = summaries[pmid]
+            item = {
+                "pmid": pmid,
+                "title": doc["title"],
+                "journal": doc["fulljournalname"],
+                "pubdate": doc["pubdate"],
+                "authors": ", ".join(a["name"] for a in doc.get("authors", [])[:5]),
+            }
+            if with_abstract:
+                # Courtesy pause to avoid hitting the rate limit
+                time.sleep(delay)
+                item["abstract"] = self.efetch_abstract(pmid)
+            results.append(item)
+        return results, total

--- a/lib/services/apis.py
+++ b/lib/services/apis.py
@@ -85,15 +85,16 @@ class NCBI:
             "User-Agent": f"arsmedicatech/0.1 ({self.email})"
         }
 
-    def fetch_ncbi_studies(self, query: str):
+    def fetch_ncbi_studies(self, query: str, debug: bool = False):
         hits, total_found = self.search_pubmed(query, max_records=10, with_abstract=True)
-        print(f"{total_found:,} articles in PubMed; showing {len(hits)} results:\n")
-        for i, art in enumerate(hits, 1):
-            print(f"{i}. {art['title']}  ({art['journal']}, {art['pubdate']})")
-            print(f"   PMID: {art['pmid']}")
-            print(f"   Authors: {art['authors']}")
-            if 'abstract' in art:
-                print(f"   Abstract (truncated): {art['abstract'][:300]}...\n")
+        if debug:
+            print(f"{total_found:,} articles in PubMed; showing {len(hits)} results:\n")
+            for i, art in enumerate(hits, 1):
+                print(f"{i}. {art['title']}  ({art['journal']}, {art['pubdate']})")
+                print(f"   PMID: {art['pmid']}")
+                print(f"   Authors: {art['authors']}")
+                if 'abstract' in art:
+                    print(f"   Abstract (truncated): {art['abstract'][:300]}...\n")
         return hits
 
     def esearch(self, query, retmax=100):

--- a/lib/services/apis.py
+++ b/lib/services/apis.py
@@ -50,10 +50,21 @@ class ClinicalTrials:
         """
         import requests
         url = "https://clinicaltrials.gov/api/v2/studies"
+
         headers = {
             "accept": "application/json"
         }
-        response = requests.get(url, headers=headers)
+
+        data = {
+            "query.cond": query
+        }
+
+        response = requests.get(
+            url,
+            params=data,
+            headers=headers
+        )
+
         if response.status_code == 200:
             data = response.json()
             return data

--- a/settings.py
+++ b/settings.py
@@ -40,3 +40,5 @@ HOST = os.environ.get('HOST', '0.0.0.0')
 print("PORT:", PORT)
 print("DEBUG:", DEBUG)
 print("HOST:", HOST)
+
+NCBI_API_KEY = os.environ.get('NCBI_API_KEY')

--- a/test/test_apis.py
+++ b/test/test_apis.py
@@ -1,0 +1,64 @@
+""""""
+
+from settings import NCBI_API_KEY, logger
+
+from lib.services.apis import Medline, ClinicalTrials, NCBI
+
+
+def test_medline():
+    medline = Medline(logger)
+    medline_data = medline.fetch_medline(icd10_code='J45.40')
+
+    assert medline_data is not None
+    assert isinstance(medline_data, dict)
+    assert 'feed' in medline_data
+
+    feed = medline_data['feed']
+
+    assert {'id', 'author', 'subtitle', 'category', 'entry'}.issubset(feed.keys())
+
+    entry = feed['entry']
+
+    assert len(entry) > 0
+
+    assert 'asthma' in entry[0]['title']['_value'].lower()
+
+def test_clinical_trials():
+    clinical_trials = ClinicalTrials(logger)
+    clinical_trials_data = clinical_trials.fetch_clinical_trials(query='asthma')
+
+    assert clinical_trials_data is not None
+    assert isinstance(clinical_trials_data, dict)
+    assert 'studies' in clinical_trials_data
+
+    studies = clinical_trials_data['studies']
+
+    assert isinstance(studies, list)
+    assert len(studies) > 0
+
+    study_1 = studies[0] if studies else None
+
+    assert {'protocolSection', 'derivedSection', 'hasResults'}.issubset(study_1.keys())
+
+def test_ncbi():
+    ncbi = NCBI('my@email.com', logger, api_key=NCBI_API_KEY)
+
+    ncbi_data = ncbi.fetch_ncbi_studies('asthma')
+
+    print(f"NCBI data: {len(ncbi_data)}")
+
+    assert ncbi is not None
+    assert isinstance(ncbi, NCBI)
+    assert ncbi.api_key == NCBI_API_KEY
+    assert ncbi.logger is not None
+
+
+def main():
+    test_medline()
+    test_clinical_trials()
+    test_ncbi()
+    print("All tests passed!")
+
+if __name__ == "__main__":
+    main()
+    print("Tests completed successfully.")


### PR DESCRIPTION
This PR includes some new services for the API layer to make third party API calls for medical knowledge including clinical trials.

This can be used in the future for LLM tool calls as well.
