### PR TITLE
Tsconfig path

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -45,4 +45,4 @@ jobs:
         run: npm test
 
       - name: TypeScript type check
-        run: npm run type-check
+        run: npx tsc --project ./config/tsconfig.json --noEmit


### PR DESCRIPTION
```
arsmedicatech@1.0.0 type-check
> tsc --project ./config/tsconfig.json --noEmit

error TS18003: No inputs were found in config file '/home/runner/work/arsmedicatech/arsmedicatech/config/tsconfig.json'. Specified 'include' paths were '["src/**/*"]' and 'exclude' paths were '["node_modules","dist"]'.
```